### PR TITLE
Mac service environment - set PATH for user service

### DIFF
--- a/daemon/service/service.go
+++ b/daemon/service/service.go
@@ -43,13 +43,14 @@ func New(conf Config) (service.Service, error) {
 		// In Mac OS, it is impossible to reliably set the PATH
 		// of a LaunchAgent outside the plist file. DRONE_RUNNER_ENVIRON
 		// and DRONE_RUNNER_ENVFILE will NOT work. So we use a custom service template.
-		c := fmt.Sprintf(launchdConfig, os.Getenv("PATH"))
+		nonRootUser := os.Getuid() != 0
 		config.Option = service.KeyValue{
 			"KeepAlive":   true,
 			"RunAtLoad":   true,
-			"UserService": os.Getuid() != 0,
-			// Custom for Mac OS
-			"LaunchdConfig": c,
+			"UserService": nonRootUser,
+		}
+		if nonRootUser {
+			config.Option["LaunchdConfig"] = fmt.Sprintf(launchdConfig, os.Getenv("PATH"))
 		}
 	case "windows":
 		if conf.Username != "" {


### PR DESCRIPTION
When installing the exec runner on Mac OS as a user service, the user would expect the system PATH for the service to reflect the PATH available at install-time - ie to run locally-installed tools, homebrew,  etc. The default system PATH on Mac OS does not include common directories such as /usr/local/bin

Unfortunately, due to the way launchd works, it is impossible to set the service PATH from DRONE_RUNNER_ENVFILE or DRONE_RUNNER_ENVIRON. Also, the various manual methods through the years for setting the environment for launchd (environment.plist, launchctl setenv, etc)  are mostly now deprecated.

This PR explicitly sets the service PATH in the plist file to that available in the shell at install-time for user (non-root) services only, which obviates the need to apply nasty workarounds. 