### PR TITLE
Add option root build path

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -25,6 +25,7 @@ import (
 type compileCommand struct {
 	*internal.Flags
 
+	Root    string
 	Source  *os.File
 	Environ map[string]string
 	Secrets map[string]string
@@ -88,6 +89,7 @@ func (c *compileCommand) run(*kingpin.ParseContext) error {
 		System:   c.System,
 		Environ:  c.Environ,
 		Secret:   secret.StaticVars(c.Secrets),
+		Root:     c.Root,
 	}
 	spec := comp.Compile(nocontext)
 
@@ -104,6 +106,10 @@ func registerCompile(app *kingpin.Application) {
 
 	cmd := app.Command("compile", "compile the yaml file").
 		Action(c.run)
+
+	cmd.Arg("root", "root build directory").
+		Default("").
+		StringVar(&c.Root)
 
 	cmd.Arg("source", "source file location").
 		Default(".drone.yml").

--- a/command/exec.go
+++ b/command/exec.go
@@ -33,6 +33,7 @@ import (
 type execCommand struct {
 	*internal.Flags
 
+	Root    string
 	Source  *os.File
 	Environ map[string]string
 	Secrets map[string]string
@@ -98,6 +99,7 @@ func (c *execCommand) run(*kingpin.ParseContext) error {
 		System:   c.System,
 		Environ:  c.Environ,
 		Secret:   secret.StaticVars(c.Secrets),
+		Root:     c.Root,
 	}
 	spec := comp.Compile(nocontext)
 
@@ -154,6 +156,10 @@ func registerExec(app *kingpin.Application) {
 
 	cmd := app.Command("exec", "executes a pipeline").
 		Action(c.run)
+
+	cmd.Arg("root", "root build directory").
+		Default("").
+		StringVar(&c.Root)
 
 	cmd.Arg("source", "source file location").
 		Default(".drone.yml").

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -66,6 +66,7 @@ type Config struct {
 		Environ  map[string]string `envconfig:"DRONE_RUNNER_ENVIRON"`
 		EnvFile  string            `envconfig:"DRONE_RUNNER_ENVFILE"`
 		Path     string            `envconfig:"DRONE_RUNNER_PATH"`
+		Root     string            `envconfig:"DRONE_RUNNER_ROOT"`
 	}
 
 	Limit struct {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -61,6 +61,7 @@ func Run(ctx context.Context, config Config) error {
 			Client:   cli,
 			Environ:  config.Runner.Environ,
 			Machine:  config.Runner.Name,
+			Root:     config.Runner.Root,
 			Reporter: tracer,
 			Match: match.Func(
 				config.Limit.Repos,

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -75,15 +75,26 @@ type Compiler struct {
 	// Secret returns a named secret value that can be injected
 	// into the pipeline step.
 	Secret secret.Provider
+
+	// Root defines the option build root path, defaults to temp directory.
+	Root string
 }
 
 // Compile compiles the configuration file.
 func (c *Compiler) Compile(ctx context.Context) *engine.Spec {
 	spec := new(engine.Spec)
-	spec.Root = filepath.Join(
-		tempdir(),
-		fmt.Sprintf("drone-%s", random()),
-	)
+
+	if c.Root != "" {
+		spec.Root = filepath.Join(
+			c.Root,
+			fmt.Sprintf("drone-%s", random()),
+		)
+	} else {
+		spec.Root = filepath.Join(
+			tempdir(),
+			fmt.Sprintf("drone-%s", random()),
+		)
+	}
 
 	spec.Platform.OS = c.Pipeline.Platform.OS
 	spec.Platform.Arch = c.Pipeline.Platform.Arch

--- a/runtime/runner.go
+++ b/runtime/runner.go
@@ -57,6 +57,9 @@ type Runner struct {
 
 	// Secret provides the compiler with secrets.
 	Secret secret.Provider
+
+	// Root defines the option build root path, defaults to temp directory.
+	Root string
 }
 
 // Run runs the pipeline stage.
@@ -198,6 +201,7 @@ func (s *Runner) Run(ctx context.Context, stage *drone.Stage) error {
 		System:   data.System,
 		Netrc:    data.Netrc,
 		Secret:   secrets,
+		Root:     s.Root,
 	}
 
 	spec := comp.Compile(ctx)


### PR DESCRIPTION
Many environments are pretty limited on disk space, especially the /tmp
partition could be quite small. For our builds on macOS we got a large
partition mounted to /Users/Shared/drone which we would like to use for
the Drone builds, this flag/env variable brings in the option to move
the build root to a different base folder.

