### PR TITLE
[docs] Add DRONE_RUNNER_ROOT to reference list

### DIFF
--- a/content/installation/reference/drone-runner-root.md
+++ b/content/installation/reference/drone-runner-root.md
@@ -1,0 +1,12 @@
+---
+date: 2000-01-01T00:00:00+00:00
+title: DRONE_RUNNER_ROOT
+author: tboerger
+weight: 1
+---
+
+Optional string value. Sets a custom root build path instead of a folder within the system temp directory.
+
+```
+DRONE_RUNNER_ROOT=/tmp
+```


### PR DESCRIPTION
This PR adds the reference documentation introduced by https://github.com/drone-runners/drone-runner-exec/pull/2