### PR TITLE
Fix nil panic on null environment variable for step

### DIFF
--- a/engine/compiler/util.go
+++ b/engine/compiler/util.go
@@ -63,6 +63,9 @@ func configureSerial(spec *engine.Spec) {
 func convertStaticEnv(src map[string]*manifest.Variable) map[string]string {
 	dst := map[string]string{}
 	for k, v := range src {
+		if v == nil {
+			continue
+		}
 		if strings.TrimSpace(v.Secret) == "" {
 			dst[k] = v.Value
 		}
@@ -76,6 +79,9 @@ func convertStaticEnv(src map[string]*manifest.Variable) map[string]string {
 func convertSecretEnv(src map[string]*manifest.Variable) []*engine.Secret {
 	dst := []*engine.Secret{}
 	for k, v := range src {
+		if v == nil {
+			continue
+		}
 		if strings.TrimSpace(v.Secret) != "" {
 			dst = append(dst, &engine.Secret{
 				Name: v.Secret,


### PR DESCRIPTION
The following in a `.drone.yml` will cause the `drone-runner-exec` process to crash (nil panic) .. 

```yaml
steps:
- name: crash-runner
  environment:
    BURN_IT_DOWN: null
```


This PR fixes it and a similar issue for `engine.Secret`

Note:  both changes are already present in [`drone-runner-docker`](https://github.com/drone-runners/drone-runner-docker/blob/master/engine/compiler/util.go#L63-L93), [`drone-runner-ssh`](https://github.com/drone-runners/drone-runner-ssh/blob/master/engine/compiler/util.go#L63-L93) and [`drone-runner-kube`](https://github.com/drone-runners/drone-runner-kube/blob/master/engine/compiler/util.go#L63-L93).